### PR TITLE
Handle docTitle non-null but empty.

### DIFF
--- a/lib/src/main/java/com/artifex/mupdf/viewer/DocumentActivity.java
+++ b/lib/src/main/java/com/artifex/mupdf/viewer/DocumentActivity.java
@@ -415,7 +415,7 @@ public class DocumentActivity extends Activity
 
 		// Set the file-name text
 		String docTitle = core.getTitle();
-		if (docTitle != null)
+		if (docTitle != null && !docTitle.isEmpty())
 			mDocNameView.setText(docTitle);
 		else
 			mDocNameView.setText(mDocTitle);


### PR DESCRIPTION
This change fixes the following problem by adding a missing check for docTitle.isEmpty().

When a PDF's metadata Title string is empty, the docNameText in the top bar is empty. Expected behavior is to show the file name in that case (which it does in MuPDF mini). 

Here is an example of a PDF with an empty title: [example.pdf](https://github.com/ArtifexSoftware/mupdf-android-viewer/files/14704902/example.pdf).
Before and after the fix:
<img src="https://github.com/ArtifexSoftware/mupdf-android-viewer/assets/72370023/c41ce903-29f3-4e42-8c1a-f4737a4329b8" width="200" /> <img src="https://github.com/ArtifexSoftware/mupdf-android-viewer/assets/72370023/3413cf5b-785e-4db9-b026-0f89a4f2c7aa" width="200" />
