### PR TITLE
share document button

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/lib/src/main/res/layout/document_activity.xml
+++ b/lib/src/main/res/layout/document_activity.xml
@@ -76,6 +76,14 @@
 					android:src="@drawable/ic_toc_white_24dp"
 					/>
 
+				<ImageButton
+					android:id="@+id/shareButton"
+					android:layout_width="wrap_content"
+					android:layout_height="wrap_content"
+					android:background="@drawable/button"
+					android:src="@drawable/ic_chevron_right_white_24dp"
+					/>
+
 			</LinearLayout>
 
 			<LinearLayout


### PR DESCRIPTION
naive implementation of a share action, to do something else with the file when muPDF is the default pdf handler (e.g. send to print app; send to email a file seen from instant messaging, and vice versa)

I think for this to be useful to more people (without intent interceptors) the uri must change from `content://` to `file://` schema, and something else on the intent should be set to avoid the default (which would be circular back to muPDF)...

(released under any version of the GPL and all that)